### PR TITLE
skip encoding text for html docs with invalid bodies

### DIFF
--- a/cli/test/test_data/text2embeddings_input/test_html.json
+++ b/cli/test/test_data/text2embeddings_input/test_html.json
@@ -15,7 +15,7 @@
     "html_data": {
         "detected_title": "Machinery of Government (MoG) changes to our department from 1 July 2022",
         "detected_date": "2020-10-22",
-        "has_valid_text": true,
+        "has_valid_text": false,
         "text_blocks": [
             {
                 "text": [

--- a/cli/test/test_text2embeddings.py
+++ b/cli/test/test_text2embeddings.py
@@ -28,6 +28,9 @@ def test_run_encoder_local(test_input_dir: Path):
         assert (Path(output_dir) / "test_pdf.npy").exists()
         assert (Path(output_dir) / "test_pdf.json").exists()
 
+        # test_html has the `has_valid_text` flag set to false, so the numpy file should only contain a description embedding
+        assert np.load(Path(output_dir) / "test_html.npy").shape == (1, 768)
+
 
 def test_run_encoder_s3(test_input_dir: Path):
     """Test that the encoder runs with S3 input and output paths and outputs the correct files."""

--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -40,21 +40,24 @@ logging.config.dictConfig(DEFAULT_LOGGING)
 
 def encode_indexer_input(
     encoder: SentenceEncoder, input: IndexerInput, batch_size: int
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> Tuple[np.ndarray, Optional[np.ndarray]]:
     """
     Produce a numpy array of description embedding and a numpy array of text embeddings for an indexer input.
 
     :param input: serialised indexer input (output from document parser)
-    :return: description embedding, text embeddings
+    :return: description embedding, text embeddings. Text embeddings are None if there were no text blocks to encode.
     """
 
     description_embedding = encoder.encode(input.document_description)
 
     text_blocks = input.get_text_blocks()
 
-    text_embeddings = encoder.encode_batch(
-        [block.to_string() for block in text_blocks], batch_size=batch_size
-    )
+    if text_blocks:
+        text_embeddings = encoder.encode_batch(
+            [block.to_string() for block in text_blocks], batch_size=batch_size
+        )
+    else:
+        text_embeddings = None
 
     return description_embedding, text_embeddings
 
@@ -172,7 +175,11 @@ def main(
 
         embeddings_output_path = output_dir_as_path / f"{task.document_id}.npy"
 
-        combined_embeddings = np.vstack([description_embedding, text_embeddings])
+        combined_embeddings = (
+            np.vstack([description_embedding, text_embeddings])
+            if text_embeddings is not None
+            else description_embedding.reshape(1, -1)
+        )
 
         task_output_path = output_dir_as_path / f"{task.document_id}.json"
         task_output_path.write_text(task.json())

--- a/src/base.py
+++ b/src/base.py
@@ -100,4 +100,7 @@ class IndexerInput(BaseModel):
         if self.document_content_type == ContentType.PDF:
             return self.pdf_data.text_blocks  # type: ignore
         elif self.document_content_type == ContentType.HTML:
-            return self.html_data.text_blocks  # type: ignore
+            if self.html_data.has_valid_text:  # type: ignore
+                return self.html_data.text_blocks  # type: ignore
+            else:
+                return []


### PR DESCRIPTION
Change to skip encoding and loading text blocks into Opensearch if the HTML parser has set the `has_valid_text` flag to `false`.