### PR TITLE
don't ignore documents with no source url in encoding step

### DIFF
--- a/cli/test/test_data/text2embeddings_input/test_no_content_type_translated_en.json
+++ b/cli/test/test_data/text2embeddings_input/test_no_content_type_translated_en.json
@@ -12,10 +12,8 @@
         "source": "test_source",
         "type": "test_type"
 },
-    "languages": [
-        "en"
-    ],
-    "translated": true,
+    "languages": null,
+    "translated": false,
     "document_slug": "YYY",
     "document_content_type": null,
     "html_data": null,

--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -165,17 +165,20 @@ def main(
             f"The following languages have been requested for encoding but are not supported by the encoder: {unsupported_languages}. Only the following languages will be encoded: {config.ENCODER_SUPPORTED_LANGUAGES}."
         )
 
+    # Encode documents either with one language where the lanugage is in the target languages, or with no language and no content type. This assumes that the document name and description are in English.
     tasks = [
         task
         for task in tasks
-        if task.languages
-        and (len(task.languages) == 1)
-        and (
-            task.languages[0]
-            in config.ENCODER_SUPPORTED_LANGUAGES.union(config.TARGET_LANGUAGES)
+        if (
+            task.languages
+            and (len(task.languages) == 1)
+            and (
+                task.languages[0]
+                in config.ENCODER_SUPPORTED_LANGUAGES.union(config.TARGET_LANGUAGES)
+            )
         )
+        or (not task.languages and task.html_data is None and task.pdf_data is None)
     ]
-
     # TODO: check we have all the files we need here i.e. (no ids * no languages)? Or do in the indexing step?
 
     if limit:


### PR DESCRIPTION
I was making the assumption that the `languages` field would not be null for documents without a source URL, which is not true. Updated the embedder to not ignore these files, and the test data to ensure the correct files are output in this case.