### PR TITLE
Enable replicas after indexing

### DIFF
--- a/cli/index_data.py
+++ b/cli/index_data.py
@@ -163,12 +163,16 @@ def populate_and_warmup_index(
         },
         embedding_dim=config.OPENSEARCH_INDEX_EMBEDDING_DIM,
     )
-    opensearch.delete_and_create_index(n_replicas=config.OPENSEARCH_INDEX_NUM_REPLICAS)
+    # Disabling replicas during indexing means that the KNN index is copied to replicas after indexing is complete rather than multiple, potentially different KNN indices being created in parallel.
+    # It should also speed up indexing.
+    opensearch.delete_and_create_index(n_replicas=0)
+
     # We disable index refreshes during indexing to speed up the indexing process,
     # and to ensure only 1 segment is created per shard. This also speeds up KNN
     # queries and aggregations according to the Opensearch and Elasticsearch docs.
     opensearch.set_index_refresh_interval(-1, timeout=60)
     opensearch.bulk_index(actions=doc_generator)
+    opensearch.set_num_replicas(config.OPENSEARCH_INDEX_NUM_REPLICAS)
 
     # TODO: we wrap this in a try/except block because for now because sometimes it times out, and we don't want the whole >1hr indexing process to fail if this happens. We should stop doing this if we ever care what the refresh interval is, i.e. when we plan on incrementally adding data to the index.
     try:

--- a/src/index.py
+++ b/src/index.py
@@ -210,3 +210,14 @@ class OpenSearchIndex:
                 f"KNN index warmup API call returned non-200 status code. Full response {response.json()}"
             )
             return False
+
+    def set_num_replicas(self, n_replicas: int):
+        """Set the number of replicas for the index.
+
+        Args:
+            n_replicas (int): number of replicas to create for the index.
+        """
+        self.opns.indices.put_settings(
+            index=self.index_name,
+            body={"index.number_of_replicas": n_replicas},
+        )


### PR DESCRIPTION
Attempted fix for an issue where each replica index stored a different version of the KNN graph the index. This seems to be because these KNN indices were being built in parallel during indexing.

This PR changes the indexer so that it builds one index, and then replicates it once built. [According to the Opensearch docs](https://opensearch.org/docs/latest/search-plugins/knn/performance-tuning/#indexing-performance-tuning) this means that the KNN indices across replicas should be exact copies.

Whether the KNN indices are exact copies can be tested using the API `/_plugins/_knn/stats?pretty` and inspecting the properties of the KNN graphs for each index across nodes. It should then be tested whether this change ensures that the KNN index is deterministic.