### PR TITLE
Unit tests for filtering text block type function

### DIFF
--- a/src/base.py
+++ b/src/base.py
@@ -146,18 +146,17 @@ class IndexerInput(BaseModel):
 
         return self
 
-    def get_text_blocks(self) -> Sequence[TextBlock]:  # type: ignore
+    def get_text_blocks(self, including_invalid_html=False) -> Sequence[TextBlock]:
         """Returns the text blocks contained in the document."""
-
         if self.document_content_type is None:
             return []
         elif self.document_content_type == CONTENT_TYPE_PDF:
-            return self.pdf_data.text_blocks  # type: ignore
+            return self.pdf_data.text_blocks
         elif self.document_content_type == CONTENT_TYPE_HTML:
-            if self.html_data.has_valid_text:  # type: ignore
-                return self.html_data.text_blocks  # type: ignore
-            else:
+            if not including_invalid_html and not self.html_data.has_valid_text:
                 return []
+            else:
+                return self.html_data.text_blocks
 
     @root_validator
     def check_html_pdf_metadata(cls, values):

--- a/src/test/test_utils.py
+++ b/src/test/test_utils.py
@@ -56,6 +56,36 @@ def test_indexer_input_array() -> list[IndexerInput]:
                 ],
             ),
             pdf_data=None,
+        ),
+        IndexerInput(
+            document_id="test_id",
+            document_metadata=DocumentMetadata(
+                publication_ts=datetime.datetime.now(),
+                date="test_date",
+                geography="test_geography",
+                category="test_category",
+                source="test_source",
+                type="test_type",
+                sectors=["test_sector"],
+            ),
+            document_name="test_name",
+            document_description="test_description",
+            document_source_url="https://www.google.com/path.html",
+            document_cdn_object="test_cdn_object",
+            document_md5_sum="test_md5_sum",
+            languages=["test_language"],
+            translated=True,
+            document_slug="test_slug",
+            document_content_type="text/html",
+            html_data=HTMLData(
+                has_valid_text=False,
+                text_blocks=[
+                    get_text_block("Table"),
+                    get_text_block("Text"),
+                    get_text_block("Google Text Block"),
+                ],
+            ),
+            pdf_data=None,
         )
     ]
 
@@ -70,13 +100,20 @@ def test_filter_on_block_type(test_indexer_input_array):
     assert len(filtered_inputs[0].html_data.text_blocks) == 3
 
     assert filtered_inputs[0].html_data.text_blocks[0].type == "Table"
-    assert filtered_inputs[0].html_data.text_blocks[0].text is not None
     assert filtered_inputs[0].html_data.text_blocks[0].text == ["test_text"]
 
     assert filtered_inputs[0].html_data.text_blocks[1].type == "Random"
-    assert filtered_inputs[0].html_data.text_blocks[1].text is not None
     assert filtered_inputs[0].html_data.text_blocks[1].text == ["test_text"]
 
     assert filtered_inputs[0].html_data.text_blocks[2].type == "Google Text Block"
-    assert filtered_inputs[0].html_data.text_blocks[2].text is not None
     assert filtered_inputs[0].html_data.text_blocks[2].text == ["test_text"]
+
+    # Assert that we can filter on IndexerInputs that don't have valid text
+    assert len(filtered_inputs[1].html_data.text_blocks) == 2
+
+    assert filtered_inputs[1].html_data.text_blocks[0].type == "Table"
+    assert filtered_inputs[1].html_data.text_blocks[0].text == ["test_text"]
+
+    assert filtered_inputs[1].html_data.text_blocks[1].type == "Google Text Block"
+    assert filtered_inputs[1].html_data.text_blocks[1].text == ["test_text"]
+

--- a/src/test/test_utils.py
+++ b/src/test/test_utils.py
@@ -1,0 +1,82 @@
+import datetime
+
+import pytest
+
+from src.base import IndexerInput, DocumentMetadata, HTMLData, TextBlock
+from src.utils import filter_on_block_type
+
+
+def get_text_block(text_block_type: str) -> TextBlock:
+    """Returns a TextBlock object with the given type."""
+    return TextBlock(
+        text=["test_text"],
+        text_block_id="test_text_block_id",
+        language="test_language",
+        type=text_block_type,
+        type_confidence=1.0,
+        coords=[(0, 0), (0, 0), (0, 0), (0, 0)],
+        page_number=0,
+    )
+
+
+@pytest.fixture
+def test_indexer_input_array() -> list[IndexerInput]:
+    """Test IndexerInput array with html containing various text block types."""
+    return [
+        IndexerInput(
+            document_id="test_id",
+            document_metadata=DocumentMetadata(
+                publication_ts=datetime.datetime.now(),
+                date="test_date",
+                geography="test_geography",
+                category="test_category",
+                source="test_source",
+                type="test_type",
+                sectors=["test_sector"],
+            ),
+            document_name="test_name",
+            document_description="test_description",
+            document_source_url="https://www.google.com/path.html",
+            document_cdn_object="test_cdn_object",
+            document_md5_sum="test_md5_sum",
+            languages=["test_language"],
+            translated=True,
+            document_slug="test_slug",
+            document_content_type="text/html",
+            html_data=HTMLData(
+                has_valid_text=True,
+                text_blocks=[
+                    get_text_block("Table"),
+                    get_text_block("Text"),
+                    get_text_block("Text"),
+                    get_text_block("Figure"),
+                    get_text_block("Text"),
+                    get_text_block("Random"),
+                    get_text_block("Google Text Block"),
+                ],
+            ),
+            pdf_data=None,
+        )
+    ]
+
+
+def test_filter_on_block_type(test_indexer_input_array):
+    """Tests that the filter_on_block_type function removes the correct text blocks."""
+
+    filtered_inputs = filter_on_block_type(
+        inputs=test_indexer_input_array, remove_block_types=["Text", "Figure"]
+    )
+
+    assert len(filtered_inputs[0].html_data.text_blocks) == 3
+
+    assert filtered_inputs[0].html_data.text_blocks[0].type == "Table"
+    assert filtered_inputs[0].html_data.text_blocks[0].text is not None
+    assert filtered_inputs[0].html_data.text_blocks[0].text == ["test_text"]
+
+    assert filtered_inputs[0].html_data.text_blocks[1].type == "Random"
+    assert filtered_inputs[0].html_data.text_blocks[1].text is not None
+    assert filtered_inputs[0].html_data.text_blocks[1].text == ["test_text"]
+
+    assert filtered_inputs[0].html_data.text_blocks[2].type == "Google Text Block"
+    assert filtered_inputs[0].html_data.text_blocks[2].text is not None
+    assert filtered_inputs[0].html_data.text_blocks[2].text == ["test_text"]

--- a/src/test/test_utils.py
+++ b/src/test/test_utils.py
@@ -124,8 +124,4 @@ def test_has_valid_text_override(test_indexer_input_array):
 
     assert test_indexer_input_array[1].get_text_blocks() == []
     assert test_indexer_input_array[1].get_text_blocks(including_invalid_html=True) is not []
-    assert test_indexer_input_array[1].get_text_blocks(including_invalid_html=True) is [
-        get_text_block("Table"),
-        get_text_block("Text"),
-        get_text_block("Google Text Block"),
-    ]
+    assert len(test_indexer_input_array[1].get_text_blocks(including_invalid_html=True)) == 3

--- a/src/test/test_utils.py
+++ b/src/test/test_utils.py
@@ -117,3 +117,15 @@ def test_filter_on_block_type(test_indexer_input_array):
     assert filtered_inputs[1].html_data.text_blocks[1].type == "Google Text Block"
     assert filtered_inputs[1].html_data.text_blocks[1].text == ["test_text"]
 
+
+def test_has_valid_text_override(test_indexer_input_array):
+    """Test that the get_text_blocks method provides the right response when using the including_invalid_html
+    parameter."""
+
+    assert test_indexer_input_array[1].get_text_blocks() == []
+    assert test_indexer_input_array[1].get_text_blocks(including_invalid_html=True) is not []
+    assert test_indexer_input_array[1].get_text_blocks(including_invalid_html=True) is [
+        get_text_block("Table"),
+        get_text_block("Text"),
+        get_text_block("Google Text Block"),
+    ]

--- a/src/utils.py
+++ b/src/utils.py
@@ -7,14 +7,32 @@ logger = logging.getLogger(__name__)
 
 def replace_text_blocks(block: IndexerInput, new_text_blocks: list[TextBlock]):
     """Updates the text blocks in the IndexerInput object."""
-    logger.debug(f"Replacing text blocks in {block.document_id}")
-
     if block.pdf_data is not None:
         block.pdf_data.text_blocks = new_text_blocks
     elif block.html_data is not None:
         block.html_data.text_blocks = new_text_blocks
 
     return block
+
+
+def filter_blocks(indexer_input: IndexerInput, remove_block_types: list[str]) -> list[TextBlock]:
+    """Given an Indexer Input filter the contained TextBlocks and return this as a list of TextBlocks."""
+    filtered_blocks = []
+    for block in indexer_input.get_text_blocks():
+        if block.type.title() not in remove_block_types:
+            filtered_blocks.append(block)
+        else:
+            logger.info(
+                f"Filtered {block.type} block from {indexer_input.document_id}.",
+                extra={
+                    "props": {
+                        "document_id": indexer_input.document_id,
+                        "block_type": block.type,
+                        "remove_block_types": remove_block_types
+                    }
+                }
+            )
+    return filtered_blocks
 
 
 def filter_on_block_type(inputs: list[IndexerInput], remove_block_types: list[str]) -> list[IndexerInput]:
@@ -27,14 +45,10 @@ def filter_on_block_type(inputs: list[IndexerInput], remove_block_types: list[st
             logger.warning(f"Blocks to filter should be of a known block type, removing {_filter} from the list.")
             remove_block_types.remove(_filter)
 
-    logger.debug(f"Filtering on block types: {remove_block_types}")
     return [
         replace_text_blocks(
             block=_input,
-            new_text_blocks=[
-                block for block in _input.get_text_blocks()
-                if block.type.title() not in remove_block_types
-            ]
+            new_text_blocks=filter_blocks(indexer_input=_input, remove_block_types=remove_block_types)
         )
         for _input in inputs
     ]

--- a/src/utils.py
+++ b/src/utils.py
@@ -18,7 +18,7 @@ def replace_text_blocks(block: IndexerInput, new_text_blocks: list[TextBlock]):
 def filter_blocks(indexer_input: IndexerInput, remove_block_types: list[str]) -> list[TextBlock]:
     """Given an Indexer Input filter the contained TextBlocks and return this as a list of TextBlocks."""
     filtered_blocks = []
-    for block in indexer_input.get_text_blocks():
+    for block in indexer_input.get_text_blocks(including_invalid_html=True):
         if block.type.title() not in remove_block_types:
             filtered_blocks.append(block)
         else:


### PR DESCRIPTION
Pipeline integration tests produced an odd result which led me to inspecting the indexer. Effectively text blocks vanished from the embeddings output for a document. Seeing as a PR to filter text blocks had just been merged this was inspected. 

What was the problem? 

The get_text_blocks method was returning [] even though text blocks existed as the IndexerInput object did not have valid text. 
![elif self  document_content_type == CONTENT_TYPE_HTML](https://github.com/climatepolicyradar/navigator-search-indexer/assets/58440325/dcd75991-c125-49fc-af05-a660437677ac)


This is set in the parser output when parsing the html document if the number of text blocks is less than an environment variable which is set in the parser. 

Thus, when trying to filter the text blocks for the desired ones an empty array was returned. 

This PR: 
- Updates the get_text_blocks function to allow for overriding the has_valid_text variable. This defaults to False so it must explicitly be set too true. 
- Unit tests to more strongly assert text block filtering and the has_valid_text override. 
- Improved logging to make it clear when blocks are filtered. 

The places that the get_text_block method are called: 
- https://github.com/climatepolicyradar/navigator-search-indexer/blob/feature/add-unit-tests-for-text-block-filtering/cli/text2embeddings.py#L58
- https://github.com/climatepolicyradar/navigator-search-indexer/blob/feature/add-unit-tests-for-text-block-filtering/cli/index_data.py#L123

This change therefore, has the potential to affect the data that we index into opensearch so it would be good to get a second pair of eyes. I've personally convinced myself that the override variable works effectively however. 