### PR TITLE
Adding test for vespa config 

### DIFF
--- a/cli/index_data.py
+++ b/cli/index_data.py
@@ -14,7 +14,7 @@ from tqdm.auto import tqdm
 from cpr_data_access.parser_models import ParserOutput
 
 from src.index.opensearch import populate_opensearch
-from src.index.vespa import populate_vespa
+from src.index.vespa_ import populate_vespa
 
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 DEFAULT_LOGGING = {

--- a/cli/test/test_index_data.py
+++ b/cli/test/test_index_data.py
@@ -13,7 +13,7 @@ from src.index.opensearch import (
     get_core_document_generator,
     get_text_document_generator,
 )
-from src.index.vespa import (
+from src.index.vespa_ import (
     _NAMESPACE,
     DOCUMENT_PASSAGE_SCHEMA,
     FAMILY_DOCUMENT_SCHEMA,

--- a/src/index/test/test_vespa.py
+++ b/src/index/test/test_vespa.py
@@ -1,0 +1,24 @@
+import pytest
+
+from src.index.vespa_ import _get_vespa_instance, VespaConfigError
+from src import config
+
+
+def test_get_vespa_instance() -> None:
+    """Test that the get_vespa_instance function works as expected."""
+
+    assert config.VESPA_INSTANCE_URL == ""
+    expected_error_string = (
+        "Vespa instance URL must be configured using environment variable: "
+        "'VESPA_INSTANCE_URL'"
+    )
+    with pytest.raises(VespaConfigError) as context:
+        _get_vespa_instance()
+    assert expected_error_string in str(context.value)
+
+    config.VESPA_INSTANCE_URL = "https://www.example.com"
+    with pytest.raises(VespaConfigError) as context:
+        _get_vespa_instance()
+    assert expected_error_string not in str(context.value)
+
+

--- a/src/index/vespa_.py
+++ b/src/index/vespa_.py
@@ -215,7 +215,7 @@ def _get_vespa_instance() -> Vespa:
     :return Vespa: a Vespa instance to use for populating a new namespace.
     """
     # TODO: consider creating a pydantic config objects & allowing pydantic to
-    # validate the config values we have/throw validation errors
+    #   validate the config values we have/throw validation errors
 
     config_issues = []
     if not config.VESPA_INSTANCE_URL:


### PR DESCRIPTION
### This Pull Request: 
--- 
- Adds a test to assert that the `_get_vespa_config` function works as expected. This was done as part of the pipeline / step functions debugging process. 
- Renames the `vespa` module to `vespa_` as it was shadowing the `vespa` package name. 
