### PR TITLE
Use base64 encoded secrets instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ dmypy.json
 
 # Pycharm
 .idea/
+
+# Misc
+secret/

--- a/cli/run.sh
+++ b/cli/run.sh
@@ -4,9 +4,11 @@ set -e
 echo Setting up for vespa
 
 mkdir -p $(dirname $VESPA_KEY_LOCATION)
-echo "${VESPA_PRIVATE_KEY}" | openssl base64 -d --out ${VESPA_KEY_LOCATION}
-
 mkdir -p $(dirname $VESPA_CERT_LOCATION)
+
+# These values where initially encoded from the key and cert with:
+# $ openssl base64 -in <file>
+echo "${VESPA_PRIVATE_KEY}" | openssl base64 -d --out ${VESPA_KEY_LOCATION}
 echo "${VESPA_PUBLIC_CERT}" | openssl base64 -d --out ${VESPA_CERT_LOCATION}
 
 python -m cli.index_data --s3 "${INDEXER_INPUT_PREFIX}" --index-type vespa

--- a/cli/run.sh
+++ b/cli/run.sh
@@ -4,9 +4,9 @@ set -e
 echo Setting up for vespa
 
 mkdir -p $(dirname $VESPA_KEY_LOCATION)
-echo "${VESPA_PRIVATE_KEY}" > ${VESPA_KEY_LOCATION}
+echo "${VESPA_PRIVATE_KEY}" | openssl base64 -d --out ${VESPA_KEY_LOCATION}
 
 mkdir -p $(dirname $VESPA_CERT_LOCATION)
-echo "${VESPA_PUBLIC_CERT}" > ${VESPA_CERT_LOCATION}
+echo "${VESPA_PUBLIC_CERT}" | openssl base64 -d --out ${VESPA_CERT_LOCATION}
 
 python -m cli.index_data --s3 "${INDEXER_INPUT_PREFIX}" --index-type vespa


### PR DESCRIPTION
We've switched to having writing the certs to pulumi as base64 encoded strings to make them easier to work with, we now need to decode them