### PR TITLE
Deep copy load files before iterating

### DIFF
--- a/src/index/vespa_.py
+++ b/src/index/vespa_.py
@@ -1,4 +1,4 @@
-import asyncio
+import copy
 import logging
 from collections import defaultdict
 from pathlib import Path
@@ -270,7 +270,8 @@ def _get_vespa_instance() -> Vespa:
 def _batch_ingest(vespa: Vespa, to_process: Mapping[SchemaName, list]):
     responses: list[VespaResponse] = []
     for schema in _SCHEMAS_TO_PROCESS:
-        if documents := to_process[schema]:
+        if to_process[schema]:
+            documents = copy.deepcopy(to_process[schema])
             _LOGGER.info(f"Processing {schema}, with {len(documents)} documents")
             responses.extend(
                 vespa.feed_batch(


### PR DESCRIPTION
We are still seeing an error with empty payloads, the theory is that the
variable is being cleared while it is being posted to the vespa instance.
This is a further attempt to either stop this from happening, or rule it
out as a theory
