### PR TITLE
fix: Optionally include dotenv to allow setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-include .env
+-include .env
 
 .PHONY: build test dev_install
 


### PR DESCRIPTION
The current `setup` target, and any other targets, will fail since the top-level `include` is a strict `include`. This makes it optional so that setup/bootstrap succeeds.