### PR TITLE
build: Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+   - package-ecosystem: pip
+     directory: /
+     schedule:
+       interval: monthly
+     ignore:
+       - dependency-name: cpr_sdk
+   - package-ecosystem: github-actions
+     directory: /
+     schedule:
+       interval: monthly
+     ignore:
+       - dependency-name: cpr_sdk
+   - package-ecosystem: pip
+     directory: /
+     schedule:
+       interval: daily
+     allow:
+       - dependency-name: cpr_sdk
+     target-branch: main


### PR DESCRIPTION
To keep our dependencies up-to-date. Check for CPR SDK's updates more regularly.