### PR TITLE
build: Add reviewers to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,16 @@ updates:
        interval: monthly
      ignore:
        - dependency-name: cpr_sdk
+     reviewers:
+       - "climatepolicyradar/deng"
    - package-ecosystem: github-actions
      directory: /
      schedule:
        interval: monthly
      ignore:
        - dependency-name: cpr_sdk
+     reviewers:
+       - "climatepolicyradar/deng"
    - package-ecosystem: pip
      directory: /
      schedule:
@@ -19,3 +23,5 @@ updates:
      allow:
        - dependency-name: cpr_sdk
      target-branch: main
+     reviewers:
+       - "climatepolicyradar/deng"


### PR DESCRIPTION
This helps with visibility of Dependabot PRs being opened, otherwise, they'll primarily be noticed when someone is looking at the PR.
