### PR TITLE
Update vespa test schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ build:
 vespa_setup: vespa_confirm_cli_installed vespa_dev_start vespa_healthy vespa_deploy_schema
 
 test:
-	docker-compose -f docker-compose.dev.yml build
-	docker-compose -f docker-compose.dev.yml run --rm navigator-search-indexer python -m pytest -vvv
+	docker compose -f docker-compose.dev.yml build
+	docker compose -f docker-compose.dev.yml run --rm navigator-search-indexer python -m pytest -vvv
 
 dev_install:
 	poetry install && poetry run pre-commit install

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   vespaindexertest:
-    image: vespaengine/vespa:8.326.37
+    image: vespaengine/vespa:8.396.18
     container_name: vespaindexertest
     ports:
       - 8080:8080

--- a/tests/fixtures/vespa_documents/family_document.json
+++ b/tests/fixtures/vespa_documents/family_document.json
@@ -5,10 +5,12 @@
             "family_source": "CCLW",
             "search_weights_ref": "id:doc_search:search_weights::default_weights",
             "family_name": "Climate Change Adaptation and Low Emissions Growth Strategy by 2035",
+            "document_title": "Climate Change Adaptation and Low Emissions Growth Strategy by 2035",
             "document_content_type": "text/html",
             "family_slug": "climate-change-adaptation-and-low-emissions-growth-strategy-by-2035_75e3",
             "document_source_url": "https://unfccc.int/sites/default/files/resource/ENG_CC%20adaptation%20and%20Low%20emission%20development%20Strategy%20BiH%202020-2030.pdf",
             "family_geography": "BIH",
+            "family_geographies": ["BIH"],
             "family_category": "Executive",
             "family_name_index": "Climate Change Adaptation and Low Emissions Growth Strategy by 2035",
             "document_languages": [
@@ -793,7 +795,21 @@
             "family_publication_year": 2020,
             "family_publication_ts": "2020-12-01T00:00:00+00:00",
             "family_description_index": "<p><span style=\"font-size: 10pt;font-family: Arial;\">This strategy upgrades the 2013 strategy on Climate Change Adaptation. It identifies six priority sectors for climate change adaptation action, namely agriculture, water management/water resources, forestry and forest resources, biodiversity and sensitive ecosystems, tourism, human health, and energy, and six priority sectors for low emissions growth, namely electricity generation, building and housing, transport, agriculture, forestry and waste. It summarises the key impacts of climate change in BiH, and outlines strategies for the transformation of BiH to a green economy, focusing on social inclusivity and gender equity.</span></p>",
-            "family_import_id": "CCLW.family.i00000003.n0000"
+            "family_import_id": "CCLW.family.i00000003.n0000",
+            "corpus_import_id": "CCLW.corpus.i00000003.n0000",
+            "corpus_type_name": "UNFCCC Submissions",
+            "collection_title": "collection one",
+            "collection_summary": "Sample collection used for tests",
+            "metadata": [
+                {
+                    "name": "sector",
+                    "value": "Price"
+                },
+                {
+                    "name": "sector",
+                    "value": "Government"
+                }
+            ]
         }
     },
     {
@@ -802,10 +818,12 @@
             "family_source": "CCLW",
             "search_weights_ref": "id:doc_search:search_weights::default_weights",
             "family_name": "Environmental Strategy for 2014-2023",
+            "document_title": "Environmental Strategy for 2014-2023",
             "document_content_type": "application/pdf",
             "family_slug": "environmental-strategy-for-2014-2023_9f8e",
             "document_source_url": "https://wedocs.unep.org/bitstream/handle/20.500.11822/9507/-Environmental_Strategy_for_the_years_2014-2023-2014Moldova_EnvironmentalStrategy_2014-202.pdf?sequence=3&isAllowed=y",
             "family_geography": "MDA",
+            "family_geographies": ["MDA"],
             "family_category": "Executive",
             "document_md5_sum": "bea7a05dae73fbbd629e687a71a15b95",
             "family_name_index": "Environmental Strategy for 2014-2023",
@@ -1592,7 +1610,29 @@
             "family_publication_ts": "2014-04-24T00:00:00+00:00",
             "family_description_index": "The Environment Strategy for Moldova for 2014-2023 was adopted by the Moldovan Government via decision No. 301 of 24.04.2014. The second of the strategy's key objectives includes the integration of \"environmental protection, sustainable development, and green economy principles, of climate change adaptation principles into all sectors of the national economy\". The strategy includes an emissions reduction target of 20% by 2020 and sets out a number of actions with regard to the institutional management of environmental matters and knowledge dissemination activities.<br><br><br><br>",
             "document_cdn_object": "MDA/2014/environmental-strategy-for-2014-2023_bea7a05dae73fbbd629e687a71a15b95.pdf",
-            "family_import_id": "CCLW.family.10014.0"
+            "family_import_id": "CCLW.family.10014.0",
+            "corpus_import_id": "CCLW.corpus.i00000003.n0001",
+            "corpus_type_name": "Laws and Policies",
+            "collection_title": "collection two",
+            "collection_summary": "Sample collection used for tests",
+            "metadata": [
+                {
+                    "name": "sector",
+                    "value": "Price"
+                },
+                {
+                    "name": "sector",
+                    "value": "Government"
+                },
+                {
+                    "name": "topic",
+                    "value": "Mitigation"
+                },
+                {
+                    "name": "instrument",
+                    "value": "Capacity building"
+                }
+            ]
         }
     }
 ]

--- a/tests/vespa_test_schema/schemas/family_document.sd
+++ b/tests/vespa_test_schema/schemas/family_document.sd
@@ -67,6 +67,11 @@ schema family_document {
             attribute: fast-search
         }
 
+        field family_geographies type array<string> {
+            indexing: attribute | summary
+            attribute: fast-search
+        }
+
         field family_source type string {
             indexing: attribute | summary
             attribute: fast-search
@@ -74,6 +79,11 @@ schema family_document {
 
         field document_import_id type string {
             indexing: summary | attribute
+        }
+
+        field document_title type string {
+            indexing: summary | attribute
+            attribute: fast-search
         }
 
         field document_slug type string {
@@ -99,6 +109,45 @@ schema family_document {
 
         field document_source_url type string {
             indexing: summary | attribute
+        }
+
+        field corpus_import_id type string {
+            indexing: summary | attribute
+            attribute: fast-search
+
+        }
+
+        field corpus_type_name type string {
+            indexing: summary | attribute
+            attribute: fast-search
+        }
+
+        field collection_title type string {
+            indexing: summary | attribute
+            attribute: fast-search
+        }
+
+        field collection_summary type string {
+            indexing: summary | attribute
+            attribute: fast-search
+        }
+
+        struct metadata_item {
+            field name type string {}
+            field value type string {}
+        }
+
+        field metadata type array<metadata_item> {
+            indexing: summary
+
+            struct-field name {
+                indexing: attribute
+                attribute: fast-search
+            }
+            struct-field value {
+                indexing: attribute
+                attribute: fast-search
+            }
         }
     }
 
@@ -152,19 +201,26 @@ schema family_document {
     }
 
     document-summary search_summary {
-        summary family_name type string {}
-        summary family_description type string {}
-        summary family_import_id type string {}
-        summary family_slug type string {}
-        summary family_category type string {}
-        summary family_publication_ts type string {}
-        summary family_geography type string {}
-        summary family_source type string {}
-        summary document_import_id type string {}
-        summary document_slug type string {}
-        summary document_languages type array<string> {}
-        summary document_content_type type string {}
-        summary document_cdn_object type string {}
-        summary document_source_url type string {}
+        summary family_name {}
+        summary family_description {}
+        summary family_import_id {}
+        summary family_slug {}
+        summary family_category {}
+        summary family_publication_ts {}
+        summary family_geography {}
+        summary family_geographies {}
+        summary family_source {}
+        summary document_import_id {}
+        summary document_title {}
+        summary document_slug {}
+        summary document_languages {}
+        summary document_content_type {}
+        summary document_cdn_object {}
+        summary document_source_url {}
+        summary metadata {}
+        summary corpus_import_id {}
+        summary corpus_type_name {}
+        summary collection_title {}
+        summary collection_summary {}
     }
 }


### PR DESCRIPTION
This updates the schema for our test instance of vespa. This is used for tests in CI, so tests passing here gives us confidence in the changes we are making to our live instances. See: 
- https://github.com/climatepolicyradar/navigator-infra/pull/684
- https://github.com/climatepolicyradar/navigator-infra/pull/686