### PR TITLE
Deal with deprecation warnings

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   vespaindexertest:
     image: vespaengine/vespa:8.396.18

--- a/tests/vespa_test_schema/schemas/document_passage.sd
+++ b/tests/vespa_test_schema/schemas/document_passage.sd
@@ -64,7 +64,7 @@ schema document_passage {
     import field search_weights_ref.passage_weight as passage_weight {}
 
     fieldset default {
-        fields: text_block, text_embedding
+        fields: text_block
     }
 
     document-summary search_summary {

--- a/tests/vespa_test_schema/schemas/document_passage.sd
+++ b/tests/vespa_test_schema/schemas/document_passage.sd
@@ -68,25 +68,25 @@ schema document_passage {
     }
 
     document-summary search_summary {
-        summary family_name type string {}
-        summary family_description type string {}
-        summary family_import_id type string {}
-        summary family_slug type string {}
-        summary family_category type string {}
-        summary family_publication_ts type string {}
-        summary family_geography type string {}
-        summary family_source type string {}
-        summary document_import_id type string {}
-        summary document_slug type string {}
-        summary document_languages type array<string> {}
-        summary document_content_type type string {}
-        summary document_cdn_object type string {}
-        summary document_source_url type string {}
-        summary text_block type string {}
-        summary text_block_id type string {}
-        summary text_block_type type string {}
-        summary text_block_page type int {}
-        summary text_block_coords type array<array<float>> {}
+        summary family_name {}
+        summary family_description {}
+        summary family_import_id {}
+        summary family_slug {}
+        summary family_category {}
+        summary family_publication_ts {}
+        summary family_geography {}
+        summary family_source {}
+        summary document_import_id {}
+        summary document_slug {}
+        summary document_languages {}
+        summary document_content_type {}
+        summary document_cdn_object {}
+        summary document_source_url {}
+        summary text_block {}
+        summary text_block_id {}
+        summary text_block_type {}
+        summary text_block_page {}
+        summary text_block_coords {}
     }
 
     rank-profile exact inherits default {

--- a/tests/vespa_test_schema/schemas/family_document.sd
+++ b/tests/vespa_test_schema/schemas/family_document.sd
@@ -155,7 +155,7 @@ schema family_document {
     import field search_weights_ref.description_weight as description_weight {}
 
     fieldset default {
-        fields: family_name_index, family_description_index, family_description_embedding
+        fields: family_name_index, family_description_index
     }
 
     rank-profile exact inherits default {


### PR DESCRIPTION
1. Remove obsolete 'version' from docker compose file
2. Remove embeddings from fieldset
    Deals with the error:
    ```
    WARNING For schema '...', fieldset 'default': Tensor fields ['...']
    cannot be mixed with non-tensor fields ['...'] in the same fieldset.
    See https://docs.vespa.ai/en/reference/schema-reference.html#fieldset
    ```
3. Remove obsolete type assignment for summaries
    Deals with the warning for each field:
    ```
    WARNING For schema '...', summary field '...': Specifying the type is
    deprecated, ignored and will be an error in Vespa 9. Remove the type
    specification to silence this warning.