### PR TITLE
Updating from CMD to EXECUTABLE.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ COPY ./.pre-commit-config.yaml ./.flake8 ./.gitignore ./
 ENV PYTHONPATH "${PYTHONPATH}:/app"
 
 # Run the indexer on the input s3 directory
-CMD [ "sh", "./cli/run.sh" ]
+ENTRYPOINT [ "sh", "./cli/run.sh" ]

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ vespa_setup: vespa_confirm_cli_installed vespa_dev_start vespa_healthy vespa_dep
 
 test:
 	docker compose -f docker-compose.dev.yml build
-	docker compose -f docker-compose.dev.yml run --rm navigator-search-indexer python -m pytest -vvv
+	docker compose -f docker-compose.dev.yml run --rm --entrypoint python navigator-search-indexer -m pytest -vvv
 
 dev_install:
 	poetry install && poetry run pre-commit install
 
 pre-commit-checks-all-files:
-	docker run --rm navigator-search-indexer pre-commit run --all-files
+	docker run --rm --entrypoint pre-commit navigator-search-indexer run --all-files
 
 # setup dev/test vespa
 vespa_confirm_cli_installed:


### PR DESCRIPTION
This Pull Request: 
---
- Is a bug fix for the search indexer failing in the pipeline run. The failure was as the docker run arguments were being interpreted as an executable. 
- [Dockerfile Reference](https://docs.docker.com/reference/dockerfile/#cmd) shows that entrypoint allows us to be explicit about what executable to use so this solves the problem of arguments being interpreted as executables.