### PR TITLE
Fix validation error in indexer due to metadata items 

### DIFF
--- a/src/index/vespa_.py
+++ b/src/index/vespa_.py
@@ -131,8 +131,8 @@ def reshape_metadata(
         metadata_items.extend(
             [
                 VespaFamilyDocument.MetadataItem(
-                    name=key, 
-                    value=str(value) if isinstance(value, int) else value)
+                    name=key, value=str(value) if isinstance(value, int) else value
+                )
                 for value in values
             ]
         )

--- a/src/index/vespa_.py
+++ b/src/index/vespa_.py
@@ -130,7 +130,9 @@ def reshape_metadata(
     for key, values in metadata.items():
         metadata_items.extend(
             [
-                VespaFamilyDocument.MetadataItem(name=key, value=value)
+                VespaFamilyDocument.MetadataItem(
+                    name=key, 
+                    value=str(value) if isinstance(value, int) else value)
                 for value in values
             ]
         )

--- a/tests/src/test_vespa.py
+++ b/tests/src/test_vespa.py
@@ -31,6 +31,10 @@ from tests.conftest import get_parser_output, FIXTURE_DIR
             [VespaFamilyDocument.MetadataItem(name="topic", value="Adaptation")],
         ),
         (
+            {"family.id": [192949]},
+            [VespaFamilyDocument.MetadataItem(name="family.id", value="192949")],
+        ),
+        (
             {
                 "hazard": [],
                 "sector": [


### PR DESCRIPTION
This Pull Request: 
---
- Integrates a fix for a validation error that was thrown in the pipeline. 
- This issue is that we provided an int for a value in the MetadataItem (probably the family.id or document.id). 
- The metadata field is just typed as `Json` and hence any schema changes upstream wouldn't get caught until this point.
- It is worth noting that the data in postgres for these documents was created via a script so this could be the cause of the error. 


![image](https://github.com/user-attachments/assets/6ce73ab5-8552-430f-9677-dcc3ff9272b0)


